### PR TITLE
deprecating

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,6 @@
 omit =
     tgbot/botapi.py
     tgbot/__main__.py
-[report]
 exclude_lines =
     # Have to re-enable the standard pragma
     pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -55,13 +55,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
     ],
     install_requires=[
-        'requests==2.20.0',
-        'peewee==2.8.0',
-        'enum==0.4.6',
+        'requests>=2.20,<3',
+        'peewee>=3,<4',
     ],
     keywords=['telegram', 'bot']
 )


### PR DESCRIPTION
releasing one last update to work with py3 but also mark as deprecated.

https://python-telegram-bot.org/ is very well maintained and feature-full.